### PR TITLE
Fixing behavior when there is no explicit output-dir parameter and minor docker-build related improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+.idea
+.git
+Dockerfile
+
+### Go template
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,13 @@
 FROM ubuntu:bionic
 MAINTAINER DeepFence
 
-RUN apt-get update && apt-get install -y git gcc cmake make build-essential python2.7 pkg-config ragel libboost-dev wget nano
+RUN apt-get update && apt-get install -y git gcc cmake make build-essential python2.7 pkg-config ragel libboost-dev wget nano && apt-get -y clean && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /usr/local/include/ && \
     cd /usr/local/include/ && \
     git clone https://github.com/intel/hyperscan.git && \
     mkdir /usr/local/include/hs && \
     cd /usr/local/include/hs && \
+    export MAKEFLAGS=-j$(nproc) && \
     cmake -DBUILD_STATIC_AND_SHARED=1 /usr/local/include/hyperscan && \
     echo "/usr/local/lib" | tee --append /etc/ld.so.conf.d/usrlocal.conf && \
     cd /usr/local/include/hs && make && make install
@@ -24,10 +25,8 @@ ENV GOPATH=/root/.go \
 RUN go get "github.com/flier/gohs/hyperscan" "gopkg.in/yaml.v3" "github.com/fatih/color"
 RUN go get "github.com/deepfence/SecretScanner"
 
-RUN mkdir -p /home/deepfence/src /home/deepfence/output
-WORKDIR /home/deepfence/src
-RUN git clone https://github.com/deepfence/SecretScanner.git
 WORKDIR /home/deepfence/src/SecretScanner
+COPY . .
 RUN go build -v -i
 WORKDIR /home/deepfence/output
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,6 @@ ENV GOPATH=/root/.go \
     CGO_CFLAGS="-I/usr/local/include/hyperscan/src" \
     LD_LIBRARY_PATH=/usr/local/lib:/usr/local/include/hs/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/go-1.14.2/bin:~/.go/bin:$PATH
-RUN go get "github.com/flier/gohs/hyperscan" "gopkg.in/yaml.v3" "github.com/fatih/color"
-RUN go get "github.com/deepfence/SecretScanner"
 
 WORKDIR /home/deepfence/src/SecretScanner
 COPY . .

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # What are Secrets?
 
 Secrets are any kind of sensitive or private data which gives authorized users permission to access critical IT infrastructure (such as accounts, devices, network, cloud based services), applications, storage, databases and other kinds of critical data for an organization. For example, passwords, AWS access IDs, AWS secret access keys, Google OAuth Key etc. are secrets. Secrets should be strictly kept private. However, sometimes attackers can easily access secrets due to flawed security policies or inadvertent mistakes by developers. Sometimes developers use default secrets or leave hard-coded secrets such as passwords, API keys, encryption keys, SSH keys, tokens etc. in container images, especially during rapid development and deployment cycles in CI/CD pipeline. Also, sometimes users store passwords in plain text. Leakage of secrets to unauthorized entities can put your organization and infrastructure at serious security risk.
- 
+
 Deepfence SecretScanner helps users scan their container images or local directories on hosts and outputs a JSON file with details of all the secrets found.
 
 Check out our [blog](https://medium.com/deepfence-cloud-native-security/detecting-secrets-to-reduce-attack-surface-3405ee6329b5) for more details.
@@ -45,11 +45,11 @@ Usage of ./SecretScanner:
 
 Install docker and run SecretScanner on a container image using the following instructions:
 
-* Build SecretScanner: 
+* Build SecretScanner:
 
-`docker build --rm=true --tag=deepfenceio/secretscanning:latest -f Dockerfile .` 
+`docker build --rm=true --tag=deepfenceio/secretscanning:latest -f Dockerfile .`
 
-* Or, pull the latest build from docker hub by doing: 
+* Or, pull the latest build from docker hub by doing:
 
 `docker pull deepfenceio/secretscanning`
 
@@ -57,17 +57,17 @@ Install docker and run SecretScanner on a container image using the following in
 
 `docker pull node:8.11`
 
-* Run SecretScanner: 
-  * Scan a container image: 
+* Run SecretScanner:
+  * Scan a container image:
 
     ```
-    docker run -it --name=deepfence-secretscanner -v $(pwd):/home/deepfence/output -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker deepfenceio/secretscanning:latest -image-name node:8.11
+    docker run -it --rm --name=deepfence-secretscanner -v $(pwd):/home/deepfence/output -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker deepfenceio/secretscanning -image-name node:8.11
     ```
-  
-  * Scan a local directory: 
+
+  * Scan a local directory:
 
     ```
-    docker run -it --name=deepfence-secretscanner -v $(pwd):/home/deepfence/output -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker deepfenceio/secretscanning:latest -local /home/deepfence/src/SecretScanner/test
+    docker run -it --rm --name=deepfence-secretscanner -v $(pwd):/home/deepfence/output -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker deepfenceio/secretscanning -local /home/deepfence/src/SecretScanner/test
     ```
 
 By default, SecretScanner will also create json files with details of all the secrets found in the current working directory. You can explicitly specify the output directory and json filename using the appropriate options.
@@ -104,5 +104,3 @@ We have built upon the configuration file from [shhgit](https://github.com/eth0i
 # Disclaimer
 
 This tool is not meant to be used for hacking. Please use it only for legitimate purposes like detecting secrets on the infrastructure you own, not on others' infrastructure. DEEPFENCE shall not be liable for loss of profit, loss of business, other financial loss, or any other loss or damage which may be caused, directly or indirectly, by the inadequacy of SecretScanner for any purpose or use thereof or by any defect or deficiency therein.
-
-

--- a/core/options.go
+++ b/core/options.go
@@ -33,7 +33,7 @@ func ParseOptions() (*Options, error) {
 		TempDirectory:       flag.String("temp-directory", os.TempDir(), "Directory to process and store repositories/matches"),
 		Local:               flag.String("local", "", "Specify local directory (absolute path) which to scan. Scans only given directory recursively."),
 		ConfigPath:          flag.String("config-path", "", "Searches for config.yaml from given directory. If not set, tries to find it from SecretScanner binary's and current directory"),
-		OutputPath:          flag.String("output-path", "", "Output directory where json file will be stored. If not set, it will output to current directory"),
+		OutputPath:          flag.String("output-path", ".", "Output directory where json file will be stored. If not set, it will output to current directory"),
 		JsonFilename:        flag.String("json-filename", "", "Output json file name. If not set, it will automatically create a filename based on image or dir name"),
 		ImageName:           flag.String("image-name", "", "Name of the image along with tag to scan for secrets"),
 		MultipleMatch:       flag.Bool("multi-match", false, "Output multiple matches of same pattern in one file. By default, only one match of a pattern is output for a file for better performance"),


### PR DESCRIPTION
* minor docker-build-related improvements:
  * we clean temporal apt files to reduce the resulting docker image size (saving around 50MiB). 
    * In fact, we could make the image much lightweight by decoupling the build and runtime stages, but that could be a parallel contribution
  * docker run examples using `--rm`, as we probably dont want to keep the resulting container to save space
  * docker run examples removing the redundant `:latest` 
  * Enabling parallel compilation of hyperscan. That reduces docker build times a lot in multicore machines
  * rather than downloading SecretScanner from git in the Dockerfile, just adding the local clone the developer may have. That let us check how local changes behave, and makes things quicker and simpler. Adding a simple .dockerignore to minimize the amount of unneeded resources we are pushing in the image
  * explicit go get of deps is not needed
* and the important thing, a bugfix: output-path should be setting the current directory ('.') as the default value; without that, a program invocation without an explicit param value was failing trying to do an mkdir against nothing, and the documented examples were actually failing:

```text
createRecursiveDir "": mkdir : no such file or directory                                                                                  
GetJsonFilepath: Could not create output dir: mkdir : no such file or directory
findSecretsInImage: mkdir : no such file or directory
main: error while scanning image: mkdir : no such file or directory
panic: Fatal error....

goroutine 1 [running]:
github.com/deepfence/SecretScanner/core.(*Logger).Log(0xc0002547d0, 0x5, 0x5a7d08, 0x24, 0xc000555f58, 0x1, 0x1)
        /home/deepfence/src/SecretScanner/core/log.go:68 +0x2a3
github.com/deepfence/SecretScanner/core.(*Logger).Fatal(...)
        /home/deepfence/src/SecretScanner/core/log.go:73
main.main()
        /home/deepfence/src/SecretScanner/main.go:139 +0x371

```