### PR TITLE
Remove baseDir from IsSkippableDir

### DIFF
--- a/core/match.go
+++ b/core/match.go
@@ -37,7 +37,7 @@ func IsSkippableDir(path string, baseDir string) bool {
 	}
 
 	for _, skippablePathIndicator := range session.Config.BlacklistedPaths {
-		if strings.Contains(path, baseDir+skippablePathIndicator) {
+		if strings.HasPrefix(path, skippablePathIndicator) {
 			return true
 		}
 	}


### PR DESCRIPTION
- I would expect that if `"{sep}var{sep}lib{sep}docker"` is included in 
`blacklisted_paths` that the contents of `/var/lib/docker` will not be
scanned
- However, when scanning docker images, `baseDir` = 
`/tmp/Deepfence/SecretScanning/df_<image_name><imagetag>/ExtractedFiles`
which means that `/var/lib/docker` is not skipped
- Removing `baseDir` from the `IsSkippableDir` check also allows for
matching multiple directories with one pattern
   - If this is seen as undesirable then we could always use `strings.HasPrefix`
   
Love the software and am keen to use it in CI pipelines but need to be able to effectively
ignore directories to control false positives 🙂 