### PR TITLE
Fix blacklisted_paths can not work on scan image feature

### DIFF
--- a/scan/process_image.go
+++ b/scan/process_image.go
@@ -130,8 +130,19 @@ func ScanSecretsInDir(layer string, baseDir string, fullDir string, isFirstSecre
 		if err != nil {
 			return err
 		}
+
+		var scanDirPath string
+		if layer != "" {
+			scanDirPath = strings.TrimPrefix(path, baseDir +  "/" + layer)
+			if scanDirPath == "" {
+				scanDirPath = "/"
+			}
+		} else {
+			scanDirPath = path
+		}
+
 		if f.IsDir() {
-			if core.IsSkippableDir(path, baseDir) {
+			if core.IsSkippableDir(scanDirPath, baseDir) {
 				return filepath.SkipDir
 			}
 			return nil


### PR DESCRIPTION
Hi, I try to use blacklisted_paths to ignore some dir when using image scan, but it not work.

In **IsSkippableDir** function, use path var to compare with skippablePathIndicator var that read from blacklisted_paths, I try to print path to I get some path problem.

For example: 
If I want to ignore /bin path, code will compare both two string by use HasPrefix
But in image scan feature, path output is like this: ```/tmp/Deepfence/SecretScanning/df_demoimage4/ExtractedFiles/<layer_id>/bin```
This is reason that I this blacklisted_paths not work
So I try use TrimPrefix to let path like this: 
Original
```/tmp/Deepfence/SecretScanning/df_demoimage4/ExtractedFiles/<layer_id>/bin```
After TrimPrefix 
```/bin```
It will work on **IsSkippableDir** function, and can successful ignore blacklisted_paths by use image scan
