### PR TITLE
(feat.) add option to run secretscanner as server in standalone mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"github.com/deepfence/SecretScanner/core"
 	"github.com/deepfence/SecretScanner/output"
 	"github.com/deepfence/SecretScanner/scan"
@@ -40,8 +41,9 @@ const (
 )
 
 var (
-	socketPath = flag.String("socket-path", "", "The gRPC server unix socket path")
-	httpPort   = flag.String("http-port", "", "When set the http server will come up at port with df es as output")
+	socketPath         = flag.String("socket-path", "", "The gRPC server unix socket path")
+	httpPort           = flag.String("http-port", "", "When set the http server will come up at port with df es as output")
+	standAloneHTTPPort = flag.String("standalone-http-port", "", "use to run secret scanner as a standalone service")
 )
 
 // Read the regex signatures from config file, options etc.
@@ -183,6 +185,11 @@ func main() {
 		}
 	} else if *httpPort != "" {
 		err := server.RunHttpServer(*httpPort)
+		if err != nil {
+			core.GetSession().Log.Fatal("main: failed to serve through http: %v", err)
+		}
+	} else if *standAloneHTTPPort != "" {
+		err := server.RunStandaloneHttpServer(*standAloneHTTPPort)
 		if err != nil {
 			core.GetSession().Log.Fatal("main: failed to serve through http: %v", err)
 		}


### PR DESCRIPTION
This PR adds the option to start the SecretScanner as a http server in standalone mode, i.e. doesn't need console to perform the scans. 
- Adds new flag `-standalone-http-port`
- Returns secret scan result in API(`/secret-scan`)  response

**Why is this PR needed?**
Enabling the support to run secretscanner as standalone service also allows this to be integrated with several other platforms like Docker extension


ref issue: https://github.com/deepfence/SecretScanner/issues/68