### PR TITLE
adding proper exclude paths https://github.com/deepfence/SecretScanner/issues/38

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,9 @@
 
 blacklisted_strings: [] # skip matches containing any of these strings (case sensitive)
 blacklisted_extensions: [".exe", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".psd", ".xcf", ".zip", ".tar.gz", ".ttf", ".lock", ".pem"]
-blacklisted_paths: ["{sep}var{sep}lib{sep}docker", "{sep}var{sep}lib{sep}containerd", "{sep}bin", "{sep}boot", "{sep}dev", "{sep}lib", "{sep}lib64", "{sep}media", "{sep}proc", "{sep}run", "{sep}sbin", "{sep}usr{sep}lib", "{sep}sys", "{sep}home{sep}kubernetes"] # use {sep} for the OS' path seperator (i.e. / or \)
+blacklisted_paths: ["{sep}var{sep}lib{sep}docker", "{sep}var-lib-docker","{sep}var{sep}lib{sep}containerd", "{sep}var-lib-containerd","{sep}bin", "{sep}boot", "{sep}dev", "{sep}lib", "{sep}lib64", "{sep}media", "{sep}proc", "{sep}run", "{sep}sbin", "{sep}usr{sep}lib", "{sep}sys", "{sep}home{sep}kubernetes"] # use {sep} for the OS' path seperator (i.e. / or \)
+exclude_paths: ["{sep}var{sep}lib{sep}docker", "{sep}var{name_sep}lib{name_sep}docker","{sep}var{sep}lib{sep}containerd", "{sep}var{name_sep}lib{name_sep}containerd"] # use {sep} for the OS' path seperator and {name_sep} for -  (i.e. / or \)
+
 
 signatures:
   - part:  'extension'

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@
 
 blacklisted_strings: [] # skip matches containing any of these strings (case sensitive)
 blacklisted_extensions: [".exe", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".psd", ".xcf", ".zip", ".tar.gz", ".ttf", ".lock", ".pem"]
-blacklisted_paths: ["{sep}var{sep}lib{sep}docker", "{sep}var-lib-docker","{sep}var{sep}lib{sep}containerd", "{sep}var-lib-containerd","{sep}bin", "{sep}boot", "{sep}dev", "{sep}lib", "{sep}lib64", "{sep}media", "{sep}proc", "{sep}run", "{sep}sbin", "{sep}usr{sep}lib", "{sep}sys", "{sep}home{sep}kubernetes"] # use {sep} for the OS' path seperator (i.e. / or \)
+blacklisted_paths: ["{sep}var{sep}lib{sep}docker", "{sep}var{sep}lib{sep}containerd", "{sep}var{sep}lib{sep}containers", "{sep}var{sep}lib{sep}crio", "{sep}var{sep}run{sep}containers", "{sep}bin", "{sep}boot", "{sep}dev", "{sep}lib", "{sep}lib64", "{sep}media", "{sep}proc", "{sep}run", "{sep}sbin", "{sep}usr{sep}lib", "{sep}sys", "{sep}home{sep}kubernetes"]
 exclude_paths: ["{sep}var{sep}lib{sep}docker", "{sep}var{name_sep}lib{name_sep}docker","{sep}var{sep}lib{sep}containerd", "{sep}var{name_sep}lib{name_sep}containerd"] # use {sep} for the OS' path seperator and {name_sep} for -  (i.e. / or \)
 
 

--- a/core/config.go
+++ b/core/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	BlacklistedStrings           []string          `yaml:"blacklisted_strings"`
 	BlacklistedExtensions        []string          `yaml:"blacklisted_extensions"`
 	BlacklistedPaths             []string          `yaml:"blacklisted_paths"`
+	ExcludePaths                 []string          `yaml:"exclude_paths"`
 	BlacklistedEntropyExtensions []string          `yaml:"blacklisted_entropy_extensions"`
 	Signatures                   []ConfigSignature `yaml:"signatures"`
 }

--- a/core/match.go
+++ b/core/match.go
@@ -37,9 +37,17 @@ func IsSkippableDir(path string, baseDir string) bool {
 	}
 
 	for _, skippablePathIndicator := range session.Config.BlacklistedPaths {
-		if strings.HasPrefix(path, skippablePathIndicator) ||  strings.HasPrefix(path, filepath.Join(baseDir, skippablePathIndicator)) {
+		if strings.HasPrefix(path, skippablePathIndicator) || strings.HasPrefix(path, filepath.Join(baseDir, skippablePathIndicator)) {
 			return true
 		}
+
+	}
+
+	for _, excludePathIndicator := range session.Config.ExcludePaths {
+		if strings.Contains(path, excludePathIndicator) || strings.Contains(path, filepath.Join(baseDir, excludePathIndicator)) {
+			return true
+		}
+
 	}
 
 	return false

--- a/core/session.go
+++ b/core/session.go
@@ -65,11 +65,19 @@ func GetSession() *Session {
 		}
 
 		pathSeparator := string(os.PathSeparator)
+		nameSeperator := "-"
 		var blacklistedPaths []string
 		for _, blacklistedPath := range session.Config.BlacklistedPaths {
 			blacklistedPaths = append(blacklistedPaths, strings.Replace(blacklistedPath, "{sep}", pathSeparator, -1))
 		}
 		session.Config.BlacklistedPaths = blacklistedPaths
+		var excludePaths []string
+		for _, excludePath := range session.Config.ExcludePaths {
+			excludePaths = append(excludePaths, strings.Replace(excludePath, "{sep}", pathSeparator, -1))
+			excludePaths = append(excludePaths, strings.Replace(excludePath, "{name_sep}", nameSeperator, -1))
+
+		}
+		session.Config.ExcludePaths = excludePaths
 
 		session.Start()
 	})


### PR DESCRIPTION
this is done to add proper exclude paths without ignoreing these paths it takes longer time for the secret scanner to complete and sometimes result in unkonwn file extensions