### PR TITLE
Allow for merging multiple config files and absolute path specification.

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -1,12 +1,14 @@
 package core
 
 import (
-	"gopkg.in/yaml.v3"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"regexp"
+
+	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
@@ -30,36 +32,103 @@ type ConfigSignature struct {
 	ID            int     `yaml:"ID,omitempty"`
 }
 
-func ParseConfig(options *Options) (*Config, error) {
-	config := &Config{}
-	var (
-		data []byte
-		err  error
-	)
+func (c *Config) Merge(in *Config) {
+	c.BlacklistedStrings = mergeStringSlices(c.BlacklistedStrings, in.BlacklistedStrings)
+	c.BlacklistedExtensions = mergeStringSlices(c.BlacklistedExtensions, in.BlacklistedExtensions)
+	c.BlacklistedPaths = mergeStringSlices(c.BlacklistedPaths, in.BlacklistedPaths)
+	c.BlacklistedEntropyExtensions = mergeStringSlices(c.BlacklistedEntropyExtensions, in.BlacklistedEntropyExtensions)
 
-	if len(*options.ConfigPath) > 0 {
-		data, err = ioutil.ReadFile(path.Join(*options.ConfigPath, "config.yaml"))
-		if err != nil {
-			return config, err
-		}
-	} else {
-		// Trying to first find the configuration next to executable
-		// Helps e.g. with Drone where workdir is different than shhgit dir
-		ex, err := os.Executable()
-		dir := filepath.Dir(ex)
-		data, err = ioutil.ReadFile(path.Join(dir, "config.yaml"))
-		if err != nil {
-			dir, _ = os.Getwd()
-			data, err = ioutil.ReadFile(path.Join(dir, "config.yaml"))
-			if err != nil {
-				return config, err
+	signatureNames := make(map[string]bool, len(c.Signatures))
+	for _, sig := range c.Signatures {
+		signatureNames[sig.Name] = true
+	}
+	for _, sig := range in.Signatures {
+		if _, exists := signatureNames[sig.Name]; exists {
+			for i, eSig := range c.Signatures {
+				if sig.Name == eSig.Name {
+					c.Signatures[i] = sig
+					break
+				}
 			}
+		} else {
+			c.Signatures = append(c.Signatures, sig)
 		}
+	}
+}
+
+func mergeStringSlices(old, new []string) []string {
+	m := make(map[string]bool, len(old))
+	for _, s := range old {
+		m[s] = true
+	}
+
+	for _, s := range new {
+		if _, ok := m[s]; !ok {
+			old = append(old, s)
+		}
+	}
+
+	return old
+}
+
+func ParseConfig(options *Options) (*Config, error) {
+	configFileDirs := options.ConfigPath.Values()
+
+	if len(configFileDirs) > 0 {
+		if *options.MergeConfigs {
+			// merge them together onto default config in order of specification
+			config, err := getDefaultConfig()
+			if err != nil {
+				return nil, err
+			}
+
+			var subConfig *Config
+			for _, dir := range configFileDirs {
+				subConfig, err = loadConfigFile(dir)
+				if err != nil {
+					return nil, err
+				}
+				config.Merge(subConfig)
+			}
+
+			return config, nil
+		} else {
+			if len(configFileDirs) > 1 {
+				return nil, fmt.Errorf("error: Multiple config paths specified, but --merge-configs is not specified")
+			}
+
+			return loadConfigFile(configFileDirs[0])
+		}
+
+	}
+
+	return getDefaultConfig()
+}
+
+// Trying to first find the configuration next to executable
+// Helps e.g. with Drone where workdir is different than shhgit dir
+func getDefaultConfig() (*Config, error) {
+	ex, err := os.Executable()
+	dir := filepath.Dir(ex)
+	config, err := loadConfigFile(dir)
+	if err != nil {
+		dir, _ = os.Getwd()
+		return loadConfigFile(dir)
+	}
+	return config, nil
+}
+
+func loadConfigFile(dir string) (*Config, error) {
+	config := &Config{}
+
+	data, err := ioutil.ReadFile(path.Join(dir, "config.yaml"))
+	if err != nil {
+		return nil, err
 	}
 
 	err = yaml.Unmarshal(data, config)
 	if err != nil {
-		return config, err
+		return nil, err
 	}
 
 	return config, nil

--- a/core/config.go
+++ b/core/config.go
@@ -118,10 +118,23 @@ func getDefaultConfig() (*Config, error) {
 	return config, nil
 }
 
-func loadConfigFile(dir string) (*Config, error) {
-	config := &Config{}
+func loadConfigFile(configPath string) (*Config, error) {
+	var (
+		config *Config = &Config{}
+		data   []byte
+		err    error
+	)
 
-	data, err := ioutil.ReadFile(path.Join(dir, "config.yaml"))
+	fstat, err := os.Stat(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if fstat.IsDir() {
+		data, err = ioutil.ReadFile(path.Join(configPath, "config.yaml"))
+	} else {
+		data, err = ioutil.ReadFile(configPath)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -1,0 +1,132 @@
+package core_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/deepfence/SecretScanner/core"
+)
+
+func Test_ConfigMerge(t *testing.T) {
+	config := &core.Config{
+		BlacklistedStrings:           []string{"base"},
+		BlacklistedExtensions:        []string{"base"},
+		BlacklistedPaths:             []string{"base"},
+		BlacklistedEntropyExtensions: []string{"base"},
+		Signatures: []core.ConfigSignature{
+			{
+				Name:          "base",
+				Part:          "base",
+				Match:         "base",
+				Regex:         "base",
+				RegexType:     "base",
+				Verifier:      "base",
+				Severity:      "base",
+				SeverityScore: 100,
+				ID:            0,
+			},
+			{
+				Name:          "overwrite",
+				Part:          "base",
+				Match:         "base",
+				Regex:         "base",
+				RegexType:     "base",
+				Verifier:      "base",
+				Severity:      "base",
+				SeverityScore: 100,
+				ID:            1,
+			},
+		},
+	}
+
+	config.Merge(&core.Config{
+		BlacklistedStrings:           []string{"merge"},
+		BlacklistedExtensions:        []string{"merge", "base"},
+		BlacklistedPaths:             []string{"base", "merge"},
+		BlacklistedEntropyExtensions: []string{"base"},
+		Signatures: []core.ConfigSignature{
+			{
+				Name:          "merge",
+				Part:          "merge",
+				Match:         "merge",
+				Regex:         "merge",
+				RegexType:     "merge",
+				Verifier:      "merge",
+				Severity:      "merge",
+				SeverityScore: 200,
+				ID:            2,
+			},
+			{
+				Name:          "overwrite",
+				Part:          "merge",
+				Match:         "merge",
+				Regex:         "merge",
+				RegexType:     "merge",
+				Verifier:      "merge",
+				Severity:      "merge",
+				SeverityScore: 200,
+				ID:            3,
+			},
+		},
+	})
+
+	expected := &core.Config{
+		BlacklistedStrings:           []string{"base", "merge"},
+		BlacklistedExtensions:        []string{"base", "merge"},
+		BlacklistedPaths:             []string{"base", "merge"},
+		BlacklistedEntropyExtensions: []string{"base"},
+		Signatures: []core.ConfigSignature{
+			{
+				Name:          "base",
+				Part:          "base",
+				Match:         "base",
+				Regex:         "base",
+				RegexType:     "base",
+				Verifier:      "base",
+				Severity:      "base",
+				SeverityScore: 100,
+				ID:            0,
+			},
+			{
+				Name:          "overwrite",
+				Part:          "merge",
+				Match:         "merge",
+				Regex:         "merge",
+				RegexType:     "merge",
+				Verifier:      "merge",
+				Severity:      "merge",
+				SeverityScore: 200,
+				ID:            3,
+			},
+			{
+				Name:          "merge",
+				Part:          "merge",
+				Match:         "merge",
+				Regex:         "merge",
+				RegexType:     "merge",
+				Verifier:      "merge",
+				Severity:      "merge",
+				SeverityScore: 200,
+				ID:            2,
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(config, expected) {
+		t.Errorf("merge does not match expected\nActual:\n%v\nExpected:\n%v", mustMarshal(config), mustMarshal(expected))
+	}
+
+}
+
+func mustMarshal(in interface{}) string {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	err := enc.Encode(in)
+	if err != nil {
+		panic(err)
+	}
+	return buf.String()
+}


### PR DESCRIPTION
This PR allows for multiple config paths to be specified, and adds the `--merge-configs` flag.  When multiple paths are specified, and the merge is enabled, it joins the configs together, layering each config on top of the default config.

Additionally it adds the ability to specify the full path to a config file, not just the directory containing a config file.  This means you can do `--config-path some/path/nonstandard.yaml`

Closes #71 