### PR TITLE
--json-file is invalid flag

### DIFF
--- a/docs/docs/secretscanner/configure/output.md
+++ b/docs/docs/secretscanner/configure/output.md
@@ -19,7 +19,7 @@ docker run -it --rm --name=deepfence_secret_scanner \
     -v $(pwd)/my-output:/home/deepfence/output \
     deepfenceio/deepfence_secret_scanner:latest --image-name node:latest \
 # highlight-next-line
-    --json-file node-secret-scan.json
+    --json-filename node-secret-scan.json
 ```
 
 You can also override the default output location (`--output-path`) in the container.


### PR DESCRIPTION
See:
```
Initializing....
flag provided but not defined: -json-file
Usage of /home/deepfence/usr/SecretScanner:
  -config-path string
        Searches for config.yaml from given directory. If not set, tries to find it from SecretScanner binary's and current directory
  -container-id string
        Id of existing container ID
  -container-ns string
        Namespace of existing container to scan, empty for docker runtime
  -debug-level string
        Debug levels are one of FATAL, ERROR, IMPORTANT, WARN, INFO, DEBUG. Only levels higher than the debug-level are displayed (default "ERROR")
  -host-mount-path string
        If scanning the host, specify the host mount path for path exclusions to work correctly.
  -http-port string
  -image-name string
        Name of the image along with tag to scan for secrets
  -json-filename string
        Output json file name. If not set, it will automatically create a filename based on image or dir name
  -local string
        Specify local directory (absolute path) which to scan. Scans only given directory recursively.
  -max-multi-match uint
        Maximum number of matches of same pattern in one file. This is used only when multi-match option is enabled. (default 3)
  -max-secrets uint
        Maximum number of secrets to find in one container image or file system. (default 1000)
  -maximum-file-size uint
        Maximum file size to process in KB (default 256)
  -multi-match
        Output multiple matches of same pattern in one file. By default, only one match of a pattern is output for a file for better performance
  -output-path string
        Output directory where json file will be stored. If not set, it will output to current directory (default ".")
  -socket-path string
        The gRPC server unix socket path
  -temp-directory string
        Directory to process and store repositories/matches (default "/tmp")
  -threads int
        Number of concurrent threads (default number of logical CPUs)
```
Correct-one (printed by binary as well): `--json-filename`