### PR TITLE
make: Ensure that libc is linked statically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ clean:
 	-rm ./SecretScanner
 
 SecretScanner: $(PWD)/**/*.go $(PWD)/agent-plugins-grpc/proto/*.go
-	go build -buildvcs=false -v .
+	go build -ldflags="-extldflags=-static" -buildvcs=false -v .
 
 .PHONY: clean


### PR DESCRIPTION
Set the `-static` ldflag to ensure that even glibc is linked statically.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>