### PR TITLE
Fix & Optimize scans

### DIFF
--- a/core/match.go
+++ b/core/match.go
@@ -114,7 +114,7 @@ func ContainsBlacklistedString(input []byte) bool {
 
 // UpdateDirsPermissionsRW Update permissions for dirs in container images, so that they can be properly deleted
 func UpdateDirsPermissionsRW(dir string) {
-	filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
+	filepath.WalkDir(dir, func(path string, f os.DirEntry, err error) error {
 		if f.IsDir() {
 			err := os.Chmod(path, 0700)
 			if err != nil {

--- a/core/options.go
+++ b/core/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	ContainerId     *string
 	ContainerNS     *string
 	Quiet           *bool
+	WorkersPerScan  *int
 }
 
 type repeatableStringValue struct {
@@ -67,6 +68,7 @@ func ParseOptions() (*Options, error) {
 		ContainerId:     flag.String("container-id", "", "Id of existing container ID"),
 		ContainerNS:     flag.String("container-ns", "", "Namespace of existing container to scan, empty for docker runtime"),
 		Quiet:           flag.Bool("quiet", false, "Don't display any output in stdout"),
+		WorkersPerScan:  flag.Int("workers-per-scan", 1, "Number of concrrent workers per scan"),
 	}
 	flag.Var(options.ConfigPath, "config-path", "Searches for config.yaml from given directory. If not set, tries to find it from SecretScanner binary's and current directory.  Can be specified multiple times.")
 	flag.Parse()

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/deepfence/vessel v0.9.1
 	github.com/fatih/color v1.14.1
 	github.com/flier/gohs v1.2.1
+	github.com/opencontainers/selinux v1.10.1
 	google.golang.org/grpc v1.52.3
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -43,7 +44,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/opencontainers/runc v1.1.2 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
-	github.com/opencontainers/selinux v1.10.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	go.opencensus.io v0.23.0 // indirect


### PR DESCRIPTION
- Stop scanning non regular files
- Avoid unnecessary syscalls by using WalkDir
- Use pwalkdir to access files concurrently to speed up scans